### PR TITLE
Print arguments passed to “bazel run”

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,6 +43,7 @@ jobs:
             build --nostamp
             build --experimental_repository_cache_hardlinks
             test --test_output=errors
+            run --noomit_run_args
           disk-cache: true
           repository-cache: true
       - name: Run tests


### PR DESCRIPTION
We never pass anything sensitive on the command line, and printing these arguments on the CI logs helps with debugging.